### PR TITLE
Change maintainer info to Red Hat ACM email

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -388,8 +388,8 @@ spec:
   - name: Gatekeeper Operator
     url: https://github.com/gatekeeper/gatekeeper-operator
   maintainers:
-  - email: ifont@redhat.com
-    name: Ivan Font
+  - email: acm-contact@redhat.com
+    name: acm-contact
   maturity: alpha
   provider:
     name: Red Hat

--- a/config/manifests/bases/gatekeeper-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gatekeeper-operator.clusterserviceversion.yaml
@@ -41,8 +41,8 @@ spec:
   - name: Gatekeeper Operator
     url: https://github.com/gatekeeper/gatekeeper-operator
   maintainers:
-  - email: ifont@redhat.com
-    name: Ivan Font
+  - email: acm-contact@redhat.com
+    name: acm-contact
   maturity: alpha
   provider:
     name: Red Hat


### PR DESCRIPTION
Same contact info as used in https://github.com/open-cluster-management/multicluster-observability-operator/blob/3805a8dcf1f4c6f18a0b98527276d8b6169d570b/config/manifests/bases/multicluster-observability-operator.clusterserviceversion.yaml#L51

Refs:
 - https://github.com/open-cluster-management/backlog/issues/13248

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>