### PR TITLE
Implement Sonarcloud scanning

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -15,6 +15,22 @@ defaults:
     shell: bash
 
 jobs:
+  gosec:
+    name: Run gosec scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Gatekeeper
+        uses: actions/checkout@v4
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@v2.15.0
+        with:
+          args: -no-fail -fmt sonarqube -out gosec.json -stdout -exclude-dir=.go -exclude-dir=test ./...
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: gosec.json
+
   verify-and-unit-tests:
     name: Run verify and unit tests
     runs-on: ubuntu-latest
@@ -51,7 +67,18 @@ jobs:
         make verify-bindata
 
     - name: Unit and Integration Tests
-      run: make test
+      run: |
+        make test
+
+        echo "::group::Test coverage"
+        make test-coverage
+        echo "::endgroup::"
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: coverage_unit.out
 
   e2e-tests:
     name: Run e2e tests

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,0 +1,14 @@
+name: Sonarcloud scan
+
+on:
+  workflow_run:
+    workflows:
+      - CI-Tests
+    types:
+      - completed
+
+jobs:
+  sonarcloud:
+    uses: stolostron/governance-policy-framework/.github/workflows/sonarcloud.yml@main
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,15 @@ tidy: ## Run go mod tidy
 	GO111MODULE=on GOFLAGS=$(GOFLAGS) go mod tidy
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" GOFLAGS=$(GOFLAGS) go test $$(go list ./... | grep -v /test/) -coverprofile cover.out
+test: manifests generate fmt vet envtest test-unit ## Run tests.
+
+.PHONY: test-unit
+test-unit:
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" GOFLAGS=$(GOFLAGS) go test $(TESTARGS) $$(go list ./... | grep -v /test/)
+
+.PHONY: test-coverage
+test-coverage: TESTARGS = -json -cover -covermode=atomic -coverprofile=coverage_unit.out
+test-coverage: test-unit
 
 .PHONY: test-e2e
 test-e2e: e2e-dependencies generate fmt vet ## Run e2e tests, using the configured Kubernetes cluster in ~/.kube/config

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=open-cluster-management_gatekeeper-operator
+sonar.projectName=gatekeeper
+sonar.organization=open-cluster-management
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,/test/**,/build/**,/vbh/**,/version/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/test/e2e/**
+sonar.go.tests.reportPaths=report.json,report_e2e.json,report_unit.json
+sonar.go.coverage.reportPaths=coverage.out,coverage_e2e.out,coverage_unit.out
+sonar.externalIssuesReportPaths=gosec.json
+sonar.qualitygate.wait=true
+sonar.qualitygate.timeout=450


### PR DESCRIPTION
Implements Sonarcloud scanning with `gosec` security scan and unit test coverage (E2E test coverage will be figured out at a later time).

ref: https://issues.redhat.com/browse/ACM-8788