### PR TITLE
MintMaker config updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "America/New_York",
-  "gomod": {
-    "enabled": false
-  },
   "kustomize": {
     "enabled": false
   },
@@ -13,18 +10,38 @@
       "**/Dockerfile"
     ]
   },
+  "gomod": {
+    "packageRules": [
+      {
+        "matchDepTypes": ["indirect"],
+        "enabled": false
+      }
+    ]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "groupName": "containerfile images ({{baseBranch}})",
+      "groupName": "containerfile images ({{{baseBranch}}})",
       "matchManagers": ["dockerfile"],
       "ignorePaths": ["**/bundle.Dockerfile.rhtap"],
       "pinDigests": true
     },
     {
-      "groupName": "containerfile images ({{baseBranch}})",
+      "groupName": "containerfile images ({{{baseBranch}}})",
       "matchManagers": ["dockerfile"],
       "ignorePaths": ["**/Dockerfile.rhtap"],
       "pinDigests": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "enabled": false,
+      "vulnerabilityAlerts": {
+        "enabled": true
+      },
+      "osvVulnerabilityAlerts": true
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,18 +15,16 @@
   },
   "packageRules": [
     {
-      "groupName": "bundle containerfile builder image",
-      "matchBaseBranches": ["/^release-[0-9]+\\.[0-9]+$/"],
+      "groupName": "containerfile images ({{baseBranch}})",
       "matchManagers": ["dockerfile"],
-      "ignorePaths": ["build/Dockerfile.rhtap"],
-      "pinDigests": false
+      "ignorePaths": ["**/bundle.Dockerfile.rhtap"],
+      "pinDigests": true
     },
     {
-      "groupName": "operator containerfile images",
-      "matchBaseBranches": ["/^release-[0-9]+\\.[0-9]+$/"],
+      "groupName": "containerfile images ({{baseBranch}})",
       "matchManagers": ["dockerfile"],
-      "ignorePaths": ["build/bundle.Dockerfile.rhtap"],
-      "pinDigests": true
+      "ignorePaths": ["**/Dockerfile.rhtap"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
Opened discussion here: https://github.com/renovatebot/renovate/discussions/37636

- Uses glob for ignorePaths and swaps the `pinDigests` ordering since it seems setting it to `true` might override and future `false`?
- Re-enables `gomod` updates