### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gatekeeper-operator-bundle-3-17

### DIFF
--- a/build/bundle.Dockerfile.rhtap
+++ b/build/bundle.Dockerfile.rhtap
@@ -25,6 +25,7 @@ LABEL com.redhat.component=gatekeeper-operator-bundle-container
 LABEL com.redhat.delivery.backport=false
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions=v4.14
+LABEL cpe="cpe:/a:redhat:gatekeeper:3.17::el9"
 # K8s/Openshift annotations
 LABEL io.k8s.display-name="Gatekeeper Operator"
 LABEL io.k8s.description="The Gatekeeper Operator installs and configures Open Policy Agent Gatekeeper."


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
