### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gatekeeper-operator-3-18

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -41,3 +41,4 @@ LABEL com.redhat.component=gatekeeper-operator-container
 LABEL io.openshift.tags="data,images"
 LABEL io.k8s.display-name="Gatekeeper Operator"
 LABEL io.k8s.description="The Gatekeeper Operator installs and configures Open Policy Agent Gatekeeper."
+LABEL cpe="cpe:/a:redhat:gatekeeper:3.18::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
