### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for gatekeeper-operator-bundle-3-19

### DIFF
--- a/build/bundle.Dockerfile.rhtap
+++ b/build/bundle.Dockerfile.rhtap
@@ -40,4 +40,4 @@ LABEL distribution-scope=public
 LABEL maintainer="acm-component-maintainers@redhat.com"
 LABEL url=https://github.com/stolostron/gatekeeper-operator
 LABEL vendor="Red Hat, Inc."
-LABEL cpe=cpe:/a:redhat:gatekeeper:3.19::el9
+LABEL cpe="cpe:/a:redhat:gatekeeper:3.19::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
