### PR TITLE
feat: add webhook timeoutSeconds configuration

### DIFF
--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -260,6 +260,14 @@ type WebhookSpecConfig struct {
 	// +optional
 	//nolint:lll
 	Operations []OperationType `json:"operations,omitempty"`
+
+	// TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+	// The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+	//
+	// +optional
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=30
+	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty"`
 }
 
 type ImageConfig struct {

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -13,7 +13,7 @@ GOFUMPT_VERSION := v0.9.1
 # https://github.com/daixiang0/gci/releases/latest
 GCI_VERSION := v0.13.7
 # https://github.com/securego/gosec/releases/latest
-GOSEC_VERSION := v2.22.8
+GOSEC_VERSION := v2.22.9
 # https://github.com/kubernetes-sigs/kubebuilder/releases/latest
 KBVERSION := 3.15.1
 # https://github.com/kubernetes/kubernetes/releases/latest

--- a/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
@@ -1290,6 +1290,14 @@ spec:
                       - '*'
                       type: string
                     type: array
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
               nodeSelector:
                 additionalProperties:
@@ -1602,6 +1610,14 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
             type: object
           status:

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -1288,6 +1288,14 @@ spec:
                       - '*'
                       type: string
                     type: array
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
               nodeSelector:
                 additionalProperties:
@@ -1600,6 +1608,14 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
             type: object
           status:

--- a/config/samples/gatekeeper_with_all_values.yaml
+++ b/config/samples/gatekeeper_with_all_values.yaml
@@ -32,6 +32,7 @@ spec:
     replicas: 2
     logLevel: ERROR
     emitAdmissionEvents: Enabled
+    timeoutSeconds: 10
     operations:
       - UPDATE
       - CREATE
@@ -57,6 +58,7 @@ spec:
   mutatingWebhookConfig:
     operations:
       - CREATE
+    timeoutSeconds: 5
     failurePolicy: Ignore
     namespaceSelector:
       matchExpressions:

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -799,6 +799,12 @@ func webhookConfigurationOverrides(
 	}
 
 	if whSpecConfig != nil {
+		if whSpecConfig.TimeoutSeconds > 0 {
+			if err := setTimeoutSeconds(obj, whSpecConfig.TimeoutSeconds, webhookName); err != nil {
+				return err
+			}
+		}
+
 		if updateFailurePolicy && !controllerDeploymentPending {
 			failurePolicy := whSpecConfig.FailurePolicy
 			if err := setFailurePolicy(obj, failurePolicy, webhookName); err != nil {
@@ -1328,6 +1334,18 @@ func setOperations(
 	}
 
 	return setWebhookConfigurationWithFn(obj, webhookName, setOperationsFn)
+}
+
+func setTimeoutSeconds(
+	obj *unstructured.Unstructured, timeoutSeconds int32, webhookName string,
+) error {
+	setTimeoutSecondsFn := func(webhook map[string]interface{}) error {
+		webhook["timeoutSeconds"] = int64(timeoutSeconds)
+
+		return nil
+	}
+
+	return setWebhookConfigurationWithFn(obj, webhookName, setTimeoutSecondsFn)
 }
 
 // Generic setters

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -1475,6 +1475,109 @@ func overrideWebhookOperations(
 	})
 }
 
+func TestWebhookTimeoutSeconds(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test with both validating and mutating webhook timeouts set
+	gatekeeper := &operatorv1alpha1.Gatekeeper{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: operatorv1alpha1.GatekeeperSpec{
+			Webhook: &operatorv1alpha1.WebhookConfig{
+				WebhookSpecConfig: operatorv1alpha1.WebhookSpecConfig{
+					TimeoutSeconds: 5,
+				},
+			},
+			MutatingWebhook: operatorv1alpha1.Enabled,
+			MutatingWebhookConfig: &operatorv1alpha1.MutatingWebhookConfig{
+				WebhookSpecConfig: operatorv1alpha1.WebhookSpecConfig{
+					TimeoutSeconds: 2,
+				},
+			},
+		},
+	}
+
+	valObj, err := util.GetManifestObject(ValidatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(logr.Logger{}, gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertTimeoutSeconds(g, valObj, ValidationGatekeeperWebhook, 5)
+	assertTimeoutSeconds(g, valObj, CheckIgnoreLabelGatekeeperWebhook, 5)
+
+	mutObj, err := util.GetManifestObject(MutatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(logr.Logger{}, gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertTimeoutSeconds(g, mutObj, MutationGatekeeperWebhook, 2)
+
+	// Test with webhook timeout set but not mutating webhook config (fallback to webhook config)
+	gatekeeperFallback := &operatorv1alpha1.Gatekeeper{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: operatorv1alpha1.GatekeeperSpec{
+			Webhook: &operatorv1alpha1.WebhookConfig{
+				WebhookSpecConfig: operatorv1alpha1.WebhookSpecConfig{
+					TimeoutSeconds: 7,
+				},
+			},
+			MutatingWebhook: operatorv1alpha1.Enabled,
+		},
+	}
+
+	mutObjFallback, err := util.GetManifestObject(MutatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(
+		logr.Logger{}, gatekeeperFallback, MutatingWebhookConfiguration, mutObjFallback, namespace, false, false,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	// Should use timeout from spec.webhook since mutatingWebhookConfig is not set
+	assertTimeoutSeconds(g, mutObjFallback, MutationGatekeeperWebhook, 7)
+
+	// Test default values (0 should not override, keeps manifest defaults)
+	gatekeeperDefault := &operatorv1alpha1.Gatekeeper{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: operatorv1alpha1.GatekeeperSpec{
+			MutatingWebhook: operatorv1alpha1.Enabled,
+		},
+	}
+
+	valObjDefault, err := util.GetManifestObject(ValidatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(
+		logr.Logger{}, gatekeeperDefault, ValidatingWebhookConfiguration, valObjDefault, namespace, false, false,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertTimeoutSeconds(g, valObjDefault, ValidationGatekeeperWebhook, 3)
+
+	mutObjDefault, err := util.GetManifestObject(MutatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(
+		logr.Logger{}, gatekeeperDefault, MutatingWebhookConfiguration, mutObjDefault, namespace, false, false,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertTimeoutSeconds(g, mutObjDefault, MutationGatekeeperWebhook, 1)
+}
+
+func assertTimeoutSeconds(g *WithT, obj *unstructured.Unstructured, webhookName string, expected int32) {
+	assertWebhooksWithFn(g, obj, func(webhook map[string]interface{}) {
+		if webhook["name"] == webhookName {
+			current, found, err := unstructured.NestedInt64(webhook, "timeoutSeconds")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(int32(current)).To(Equal(expected))
+		}
+	})
+}
+
 func getContainerArgumentsMap(g *WithT, obj *unstructured.Unstructured) map[string][]string {
 	argsMap := make(map[string][]string)
 

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1296,6 +1296,14 @@ spec:
                       - '*'
                       type: string
                     type: array
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
               nodeSelector:
                 additionalProperties:
@@ -1608,6 +1616,14 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  timeoutSeconds:
+                    description: |-
+                      TimeoutSeconds specifies the timeout for the admission webhook in seconds.
+                      The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.
+                    format: int32
+                    maximum: 30
+                    minimum: 1
+                    type: integer
                 type: object
             type: object
           status:

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -483,6 +483,16 @@ var _ = Describe("Gatekeeper", func() {
 				controllers.MutationGatekeeperWebhook,
 				test.DefaultDeployment.NamespaceSelector)
 
+			byCheckingTimeoutSeconds(ctx, &validatingWebhookName, "default",
+				util.ValidatingWebhookConfigurationKind,
+				controllers.ValidationGatekeeperWebhook,
+				3)
+
+			byCheckingTimeoutSeconds(ctx, &mutatingWebhookName, "default",
+				util.MutatingWebhookConfigurationKind,
+				controllers.MutationGatekeeperWebhook,
+				1)
+
 			By("Checking default audit interval", func() {
 				_, found := getContainerArg(auditContainer.Args, controllers.AuditIntervalArg)
 				Expect(found).To(BeFalse())
@@ -605,6 +615,11 @@ var _ = Describe("Gatekeeper", func() {
 				util.ValidatingWebhookConfigurationKind,
 				controllers.ValidationGatekeeperWebhook,
 				gatekeeper.Spec.Webhook.NamespaceSelector)
+
+			byCheckingTimeoutSeconds(ctx, &validatingWebhookName, "expected",
+				util.ValidatingWebhookConfigurationKind,
+				controllers.ValidationGatekeeperWebhook,
+				gatekeeper.Spec.Webhook.TimeoutSeconds)
 
 			By("Checking expected audit interval", func() {
 				value, found := getContainerArg(auditContainer.Args, controllers.AuditIntervalArg)
@@ -763,6 +778,11 @@ var _ = Describe("Gatekeeper", func() {
 				controllers.MutationGatekeeperWebhook,
 				gatekeeper.Spec.Webhook.NamespaceSelector)
 
+			byCheckingTimeoutSeconds(ctx, &mutatingWebhookName, "expected",
+				util.MutatingWebhookConfigurationKind,
+				controllers.MutationGatekeeperWebhook,
+				gatekeeper.Spec.MutatingWebhookConfig.TimeoutSeconds)
+
 			By("Checking expected log-mutations setting", func() {
 				value, found := getContainerArg(webhookContainer.Args, controllers.LogMutationsArg)
 				Expect(found).To(BeTrue())
@@ -893,6 +913,68 @@ var _ = Describe("Gatekeeper", func() {
 				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(mutatingWebhookConfiguration.Webhooks[0].Rules[0].Operations).Should(HaveLen(3))
 			}, timeout, pollInterval).Should(Succeed())
+		})
+
+		It("Updates webhook timeout seconds", func(ctx SpecContext) {
+			gatekeeper := &v1alpha1.Gatekeeper{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: gatekeeperNamespace,
+					Name:      "gatekeeper",
+				},
+				Spec: v1alpha1.GatekeeperSpec{
+					Webhook: &v1alpha1.WebhookConfig{
+						WebhookSpecConfig: v1alpha1.WebhookSpecConfig{
+							TimeoutSeconds: 15,
+						},
+					},
+					MutatingWebhook: v1alpha1.Enabled,
+					MutatingWebhookConfig: &v1alpha1.MutatingWebhookConfig{
+						WebhookSpecConfig: v1alpha1.WebhookSpecConfig{
+							TimeoutSeconds: 8,
+						},
+					},
+				},
+			}
+			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
+
+			By("Wait until new Deployments loaded")
+			gatekeeperDeployments(ctx)
+
+			By("ValidatingWebhookConfiguration should have configured timeout")
+			byCheckingTimeoutSeconds(ctx, &validatingWebhookName, "initial validating",
+				util.ValidatingWebhookConfigurationKind,
+				controllers.ValidationGatekeeperWebhook,
+				15)
+
+			By("MutatingWebhookConfiguration should have configured timeout")
+			byCheckingTimeoutSeconds(ctx, &mutatingWebhookName, "initial mutating",
+				util.MutatingWebhookConfigurationKind,
+				controllers.MutationGatekeeperWebhook,
+				8)
+
+			By("Update Gatekeeper with new timeout values")
+			Eventually(func() error {
+				err := K8sClient.Get(ctx, gatekeeperName, gatekeeper)
+				if err != nil {
+					return err
+				}
+				gatekeeper.Spec.Webhook.TimeoutSeconds = 20
+				gatekeeper.Spec.MutatingWebhookConfig.TimeoutSeconds = 12
+
+				return K8sClient.Update(ctx, gatekeeper)
+			}, timeout, pollInterval).Should(Succeed())
+
+			By("ValidatingWebhookConfiguration should have updated timeout")
+			byCheckingTimeoutSeconds(ctx, &validatingWebhookName, "updated validating",
+				util.ValidatingWebhookConfigurationKind,
+				controllers.ValidationGatekeeperWebhook,
+				20)
+
+			By("MutatingWebhookConfiguration should have updated timeout")
+			byCheckingTimeoutSeconds(ctx, &mutatingWebhookName, "updated mutating",
+				util.MutatingWebhookConfigurationKind,
+				controllers.MutationGatekeeperWebhook,
+				12)
 		})
 	})
 
@@ -1186,6 +1268,22 @@ func byCheckingNamespaceSelector(ctx SpecContext, webhookNamespacedName *types.N
 	})
 }
 
+func byCheckingTimeoutSeconds(ctx SpecContext, webhookNamespacedName *types.NamespacedName,
+	testName, kind, webhookName string, timeoutSeconds int32,
+) {
+	By(fmt.Sprintf("Checking %s timeout seconds", testName), func() {
+		webhookConfiguration := &unstructured.Unstructured{}
+		webhookConfiguration.SetAPIVersion(admregv1.SchemeGroupVersion.String())
+		webhookConfiguration.SetKind(kind)
+		Eventually(func(g Gomega) {
+			err := K8sClient.Get(ctx, *webhookNamespacedName, webhookConfiguration)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			assertTimeoutSeconds(g, webhookConfiguration, webhookName, timeoutSeconds)
+		}, timeout, pollInterval).Should(Succeed())
+	})
+}
+
 func assertNamespaceSelector(
 	g Gomega, obj *unstructured.Unstructured, webhookName string, expected *metav1.LabelSelector,
 ) {
@@ -1210,6 +1308,26 @@ func assertNamespaceSelector(
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(nsSelectorTyped).To(BeEquivalentTo(expected))
+		}
+	}
+}
+
+func assertTimeoutSeconds(
+	g Gomega, obj *unstructured.Unstructured, webhookName string, expected int32,
+) {
+	webhooks, found, err := unstructured.NestedSlice(obj.Object, "webhooks")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+
+	for _, webhook := range webhooks {
+		w, ok := webhook.(map[string]any)
+		g.Expect(ok).To(BeTrue())
+
+		if w["name"] == webhookName {
+			timeout, found, err := unstructured.NestedInt64(w, "timeoutSeconds")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(int32(timeout)).To(Equal(expected))
 		}
 	}
 }


### PR DESCRIPTION
Leverages the fact that it has a validation that it be an integer 1-30 to determine whether it's been set by the user. This allows it to stay in the common config shared by the validating/mutating webhooks rather than having them separate.

ref: https://issues.redhat.com/browse/ACM-23810

Assisted-by: Cursor and Claude Code using claude-4-sonnet
