### PR TITLE
feat: add override for webhook configuration rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ OLM_VERSION ?= v0.27.0
 # https://github.com/operator-framework/operator-sdk/releases/latest
 OPERATOR_SDK_VERSION ?= v1.34.1
 # https://github.com/kubernetes/kubernetes/releases/latest
-KUBERNETES_VERSION ?= v1.29.4
+# https://hub.docker.com/r/kindest/node/tags
+KUBERNETES_VERSION ?= v1.33.4
 # https://github.com/bats-core/bats-core/releases/latest
 BATS_VERSION ?= 1.11.0
 
@@ -446,11 +447,11 @@ kind-load-image:
 	kind load docker-image $(IMG) --name $(KIND_NAME)
 
 .PHONY: kind-bootstrap-cluster
-kind-bootstrap-cluster: test-cluster install dev-build kind-load-image
+kind-bootstrap-cluster: test-cluster install docker-build kind-load-image
+	$(MAKE) deploy-ci NAMESPACE=$(NAMESPACE) IMG=$(IMG)
 	kubectl label ns $(NAMESPACE)  --overwrite pod-security.kubernetes.io/audit=privileged
 	kubectl label ns $(NAMESPACE)  --overwrite pod-security.kubernetes.io/enforce=privileged
 	kubectl label ns $(NAMESPACE)  --overwrite pod-security.kubernetes.io/warn=privileged
-	$(MAKE) deploy-ci NAMESPACE=$(NAMESPACE) IMG=$(IMG)
 	kubectl -n $(NAMESPACE) wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
 
 CLUSTER_NAME = kind

--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -270,12 +270,21 @@ type WebhookSpecConfig struct {
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 
 	// Operations specifies a list of API operations to be checked by the admission webhook. The
-	// default value is ["CREATE","UPDATE"].
+	// default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
 	// See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
 	//
 	// +optional
 	//nolint:lll
 	Operations []OperationType `json:"operations,omitempty"`
+
+	// Rules overwrites the rules configuration in the webhook configuration. When set, this field
+	// takes precedence over the Operations field.
+	// See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+	//
+	// +optional
+	//nolint:lll
+	// +kubebuilder:validation:MinItems:=1
+	Rules []admregv1.RuleWithOperations `json:"rules,omitempty"`
 
 	// TimeoutSeconds specifies the timeout for the admission webhook in seconds.
 	// The default is 3 seconds for validating webhooks and 1 second for mutating webhooks.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -342,6 +343,13 @@ func (in *WebhookSpecConfig) DeepCopyInto(out *WebhookSpecConfig) {
 		in, out := &in.Operations, &out.Operations
 		*out = make([]OperationType, len(*in))
 		copy(*out, *in)
+	}
+	if in.Rules != nil {
+		in, out := &in.Rules, &out.Rules
+		*out = make([]admissionregistrationv1.RuleWithOperations, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
@@ -1294,7 +1294,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1305,6 +1305,81 @@ spec:
                       - DELETE
                       - '*'
                       type: string
+                    type: array
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
                     type: array
                   timeoutSeconds:
                     description: |-
@@ -1555,7 +1630,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1639,6 +1714,81 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
+                    type: array
                   timeoutSeconds:
                     description: |-
                       TimeoutSeconds specifies the timeout for the admission webhook in seconds.

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -1292,7 +1292,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1303,6 +1303,81 @@ spec:
                       - DELETE
                       - '*'
                       type: string
+                    type: array
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
                     type: array
                   timeoutSeconds:
                     description: |-
@@ -1553,7 +1628,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1637,6 +1712,81 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
+                    type: array
                   timeoutSeconds:
                     description: |-
                       TimeoutSeconds specifies the timeout for the admission webhook in seconds.

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -651,7 +651,11 @@ func crOverrides(
 		if gatekeeper.Spec.MutatingWebhookConfig != nil {
 			whSpecConfig = &gatekeeper.Spec.MutatingWebhookConfig.WebhookSpecConfig
 		} else if gatekeeper.Spec.Webhook != nil {
-			whSpecConfig = &gatekeeper.Spec.Webhook.WebhookSpecConfig
+			// Use webhook config but exclude Rules field
+			// since Rules in spec.webhook should only apply to validating webhook
+			whSpecConfigCopy := gatekeeper.Spec.Webhook.WebhookSpecConfig
+			whSpecConfigCopy.Rules = nil
+			whSpecConfig = &whSpecConfigCopy
 		}
 
 		err := webhookConfigurationOverrides(obj, whSpecConfig, namespace,
@@ -821,8 +825,15 @@ func webhookConfigurationOverrides(
 			}
 		}
 
-		if err := setOperations(obj, whSpecConfig.Operations, webhookName); err != nil {
-			return err
+		// Rules takes precedence over Operations
+		if len(whSpecConfig.Rules) > 0 {
+			if err := setRules(obj, whSpecConfig.Rules, webhookName); err != nil {
+				return err
+			}
+		} else if whSpecConfig.Operations != nil {
+			if err := setOperations(obj, whSpecConfig.Operations, webhookName); err != nil {
+				return err
+			}
 		}
 
 		//nolint:lll
@@ -1339,6 +1350,30 @@ func setOperations(
 	}
 
 	return setWebhookConfigurationWithFn(obj, webhookName, setOperationsFn)
+}
+
+func setRules(
+	obj *unstructured.Unstructured, rules []admregv1.RuleWithOperations, webhookName string,
+) error {
+	// If no rules is provided, no override for rules
+	if rules == nil {
+		return nil
+	}
+
+	setRulesFn := func(webhook map[string]interface{}) error {
+		converted := make([]interface{}, 0, len(rules))
+		for _, rule := range rules {
+			converted = append(converted, util.ToMap(rule))
+		}
+
+		if err := unstructured.SetNestedSlice(webhook, converted, "rules"); err != nil {
+			return errors.Wrapf(err, "Failed to set webhook rules")
+		}
+
+		return nil
+	}
+
+	return setWebhookConfigurationWithFn(obj, webhookName, setRulesFn)
 }
 
 func setTimeoutSeconds(

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -1625,6 +1625,153 @@ func overrideWebhookOperations(
 	})
 }
 
+func TestWebhookRules(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create custom rules
+	rules := []admregv1.RuleWithOperations{
+		{
+			Operations: []admregv1.OperationType{"CREATE", "UPDATE"},
+			Rule: admregv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"pods"},
+			},
+		},
+		{
+			Operations: []admregv1.OperationType{"DELETE"},
+			Rule: admregv1.Rule{
+				APIGroups:   []string{"apps"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"deployments"},
+			},
+		},
+	}
+
+	// Test that Rules overrides Operations
+	operations := []operatorv1alpha1.OperationType{"CONNECT"}
+
+	gatekeeper := defaultGatekeeper()
+	gatekeeper.Spec.Webhook = &operatorv1alpha1.WebhookConfig{
+		WebhookSpecConfig: operatorv1alpha1.WebhookSpecConfig{
+			Operations: operations, // This should be ignored
+			Rules:      rules,
+		},
+	}
+
+	// Test validating webhook - should use rules from spec.webhook
+	valObj, err := util.GetManifestObject(ValidatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(logr.Logger{}, gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertWebhookRules(g, valObj, ValidationGatekeeperWebhook, rules)
+
+	// Test mutating webhook - should NOT use rules from spec.webhook
+	// Rules in spec.webhook should only apply to validating webhook
+	mutObj, err := util.GetManifestObject(MutatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(logr.Logger{}, gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	// Verify that rules from spec.webhook were NOT applied - should use configured operations
+	assertWebhookOperations(g, mutObj, MutationGatekeeperWebhook, operations)
+
+	// Test with separate mutating webhook config
+	gatekeeper.Spec.MutatingWebhookConfig = &operatorv1alpha1.MutatingWebhookConfig{
+		WebhookSpecConfig: operatorv1alpha1.WebhookSpecConfig{
+			Rules: []admregv1.RuleWithOperations{
+				{
+					Operations: []admregv1.OperationType{"CREATE"},
+					Rule: admregv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"configmaps"},
+					},
+				},
+			},
+		},
+	}
+
+	mutObj2, err := util.GetManifestObject(MutatingWebhookConfiguration)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = crOverrides(logr.Logger{}, gatekeeper, MutatingWebhookConfiguration, mutObj2, namespace, false, false)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertWebhookRules(g, mutObj2, MutationGatekeeperWebhook, gatekeeper.Spec.MutatingWebhookConfig.Rules)
+}
+
+func assertWebhookRules(
+	g *WithT, obj *unstructured.Unstructured, webhookName string, expected []admregv1.RuleWithOperations,
+) {
+	assertWebhooksWithFn(g, obj, func(webhook map[string]interface{}) {
+		if webhook["name"] == webhookName {
+			current, found, err := unstructured.NestedSlice(webhook, "rules")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(current).To(HaveLen(len(expected)))
+
+			for i, rule := range current {
+				ruleMap := rule.(map[string]interface{})
+				expectedRule := expected[i]
+
+				// Check operations
+				ops, found, err := unstructured.NestedStringSlice(ruleMap, "operations")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(ops).To(HaveLen(len(expectedRule.Operations)))
+
+				for j, op := range ops {
+					g.Expect(op).To(Equal(string(expectedRule.Operations[j])))
+				}
+
+				// Check apiGroups
+				apiGroups, found, err := unstructured.NestedStringSlice(ruleMap, "apiGroups")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(apiGroups).To(Equal(expectedRule.APIGroups))
+
+				// Check apiVersions
+				apiVersions, found, err := unstructured.NestedStringSlice(ruleMap, "apiVersions")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(apiVersions).To(Equal(expectedRule.APIVersions))
+
+				// Check resources
+				resources, found, err := unstructured.NestedStringSlice(ruleMap, "resources")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(resources).To(Equal(expectedRule.Resources))
+			}
+		}
+	})
+}
+
+func assertWebhookOperations(
+	g *WithT, obj *unstructured.Unstructured, webhookName string, expected []operatorv1alpha1.OperationType,
+) {
+	assertWebhooksWithFn(g, obj, func(webhook map[string]interface{}) {
+		if webhook["name"] == webhookName {
+			rules, found, err := unstructured.NestedSlice(webhook, "rules")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(rules).To(HaveLen(1))
+
+			ruleMap := rules[0].(map[string]interface{})
+
+			// Check operations
+			ops, found, err := unstructured.NestedStringSlice(ruleMap, "operations")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(ops).To(HaveLen(len(expected)))
+
+			for j, op := range ops {
+				g.Expect(op).To(Equal(string(expected[j])))
+			}
+		}
+	})
+}
+
 func TestWebhookTimeoutSeconds(t *testing.T) {
 	g := NewWithT(t)
 

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1300,7 +1300,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1311,6 +1311,81 @@ spec:
                       - DELETE
                       - '*'
                       type: string
+                    type: array
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
                     type: array
                   timeoutSeconds:
                     description: |-
@@ -1561,7 +1636,7 @@ spec:
                   operations:
                     description: |-
                       Operations specifies a list of API operations to be checked by the admission webhook. The
-                      default value is ["CREATE","UPDATE"].
+                      default value is ["CREATE","UPDATE"]. This is overridden if Rules is set.
                       See https://open-policy-agent.github.io/gatekeeper/website/docs/customize-admission/#enable-validation-of-delete-operations.
                     items:
                       description: OperationType specifies an operation for a request.
@@ -1645,6 +1720,81 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  rules:
+                    description: |-
+                      Rules overwrites the rules configuration in the webhook configuration. When set, this field
+                      takes precedence over the Operations field.
+                      See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.
+                    items:
+                      description: |-
+                        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
+                        sure that all the tuple expansions are valid.
+                      properties:
+                        apiGroups:
+                          description: |-
+                            APIGroups is the API groups the resources belong to. '*' is all groups.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        apiVersions:
+                          description: |-
+                            APIVersions is the API versions the resources belong to. '*' is all versions.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        operations:
+                          description: |-
+                            Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+                            for all of those operations and any future admission operations that are added.
+                            If '*' is present, the length of the slice must be one.
+                            Required.
+                          items:
+                            description: OperationType specifies an operation for
+                              a request.
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Resources is a list of resources this rule applies to.
+
+                            For example:
+                            'pods' means pods.
+                            'pods/log' means the log subresource of pods.
+                            '*' means all resources, but not subresources.
+                            'pods/*' means all subresources of pods.
+                            '*/scale' means all scale subresources.
+                            '*/*' means all resources and their subresources.
+
+                            If wildcard is present, the validation rule will ensure resources do not
+                            overlap with each other.
+
+                            Depending on the enclosing object, subresources might not be allowed.
+                            Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        scope:
+                          description: |-
+                            scope specifies the scope of this rule.
+                            Valid values are "Cluster", "Namespaced", and "*"
+                            "Cluster" means that only cluster-scoped resources will match this rule.
+                            Namespace API objects are cluster-scoped.
+                            "Namespaced" means that only namespaced resources will match this rule.
+                            "*" means that there are no scope restrictions.
+                            Subresources match the scope of their parent resource.
+                            Default is "*".
+                          type: string
+                      type: object
+                    minItems: 1
+                    type: array
                   timeoutSeconds:
                     description: |-
                       TimeoutSeconds specifies the timeout for the admission webhook in seconds.

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -1004,6 +1004,184 @@ var _ = Describe("Gatekeeper", func() {
 				controllers.MutationGatekeeperWebhook,
 				12)
 		})
+
+		It("Override webhook rules with custom rules", func(ctx SpecContext) {
+			// Custom rules for validating webhook
+			validatingRules := []admregv1.RuleWithOperations{
+				{
+					Operations: []admregv1.OperationType{"CREATE", "UPDATE"},
+					Rule: admregv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				},
+			}
+
+			// Custom rules for mutating webhook
+			mutatingRules := []admregv1.RuleWithOperations{
+				{
+					Operations: []admregv1.OperationType{"CREATE"},
+					Rule: admregv1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"deployments"},
+					},
+				},
+			}
+
+			gatekeeper := &v1alpha1.Gatekeeper{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: gatekeeperNamespace,
+					Name:      "gatekeeper",
+				},
+				Spec: v1alpha1.GatekeeperSpec{
+					Webhook: &v1alpha1.WebhookConfig{
+						WebhookSpecConfig: v1alpha1.WebhookSpecConfig{
+							Operations: []v1alpha1.OperationType{"CONNECT"}, // This should be ignored
+							Rules:      validatingRules,
+						},
+					},
+					MutatingWebhook: v1alpha1.Enabled,
+					MutatingWebhookConfig: &v1alpha1.MutatingWebhookConfig{
+						WebhookSpecConfig: v1alpha1.WebhookSpecConfig{
+							Operations: []v1alpha1.OperationType{"DELETE"}, // This should also be ignored
+							Rules:      mutatingRules,
+						},
+					},
+				},
+			}
+			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
+
+			By("Wait until new Deployments loaded")
+			gatekeeperDeployments(ctx)
+
+			By("ValidatingWebhookConfiguration should have custom rules, not operations")
+			validatingWebhookConfiguration := &admregv1.ValidatingWebhookConfiguration{}
+			Eventually(func(g Gomega) {
+				err := K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				// Verify the rules match what we specified
+				g.Expect(validatingWebhookConfiguration.Webhooks[0].Rules).Should(HaveLen(1))
+				rule := validatingWebhookConfiguration.Webhooks[0].Rules[0]
+				g.Expect(rule.Operations).Should(ConsistOf(admregv1.Create, admregv1.Update))
+				g.Expect(rule.APIGroups).Should(Equal([]string{""}))
+				g.Expect(rule.APIVersions).Should(Equal([]string{"v1"}))
+				g.Expect(rule.Resources).Should(Equal([]string{"pods"}))
+			}, timeout, pollInterval).Should(Succeed())
+
+			By("MutatingWebhookConfiguration should have custom rules, not operations")
+			mutatingWebhookConfiguration := &admregv1.MutatingWebhookConfiguration{}
+			Eventually(func(g Gomega) {
+				err := K8sClient.Get(ctx, mutatingWebhookName, mutatingWebhookConfiguration)
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				// Verify the rules match what we specified
+				g.Expect(mutatingWebhookConfiguration.Webhooks[0].Rules).Should(HaveLen(1))
+				rule := mutatingWebhookConfiguration.Webhooks[0].Rules[0]
+				g.Expect(rule.Operations).Should(ConsistOf(admregv1.Create))
+				g.Expect(rule.APIGroups).Should(Equal([]string{"apps"}))
+				g.Expect(rule.APIVersions).Should(Equal([]string{"v1"}))
+				g.Expect(rule.Resources).Should(Equal([]string{"deployments"}))
+			}, timeout, pollInterval).Should(Succeed())
+
+			By("Update rules and verify changes are propagated")
+			Eventually(func() error {
+				err := K8sClient.Get(ctx, gatekeeperName, gatekeeper)
+				if err != nil {
+					return err
+				}
+				gatekeeper.Spec.Webhook.Rules = []admregv1.RuleWithOperations{
+					{
+						Operations: []admregv1.OperationType{"DELETE"},
+						Rule: admregv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"configmaps"},
+						},
+					},
+				}
+
+				return K8sClient.Update(ctx, gatekeeper)
+			}, timeout, pollInterval).Should(Succeed())
+
+			By("ValidatingWebhookConfiguration should have updated rules")
+			Eventually(func(g Gomega) {
+				err := K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				g.Expect(validatingWebhookConfiguration.Webhooks[0].Rules).Should(HaveLen(1))
+				rule := validatingWebhookConfiguration.Webhooks[0].Rules[0]
+				g.Expect(rule.Operations).Should(ConsistOf(admregv1.Delete))
+				g.Expect(rule.Resources).Should(Equal([]string{"configmaps"}))
+			}, timeout*2, pollInterval).Should(Succeed())
+		})
+
+		It("Webhook rules should only apply to validating webhook, not mutating webhook", func(ctx SpecContext) {
+			// Custom rules for validating webhook
+			validatingRules := []admregv1.RuleWithOperations{
+				{
+					Operations: []admregv1.OperationType{"CREATE", "UPDATE"},
+					Rule: admregv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				},
+			}
+
+			gatekeeper := &v1alpha1.Gatekeeper{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: gatekeeperNamespace,
+					Name:      "gatekeeper",
+				},
+				Spec: v1alpha1.GatekeeperSpec{
+					Webhook: &v1alpha1.WebhookConfig{
+						WebhookSpecConfig: v1alpha1.WebhookSpecConfig{
+							Rules: validatingRules,
+						},
+					},
+					MutatingWebhook: v1alpha1.Enabled,
+					// Note: MutatingWebhookConfig is NOT set, so it should use defaults
+				},
+			}
+			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
+
+			By("Wait until new Deployments loaded")
+			gatekeeperDeployments(ctx)
+
+			By("ValidatingWebhookConfiguration should have custom rules from spec.webhook")
+			validatingWebhookConfiguration := &admregv1.ValidatingWebhookConfiguration{}
+			Eventually(func(g Gomega) {
+				err := K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				// Verify the rules match what we specified
+				g.Expect(validatingWebhookConfiguration.Webhooks[0].Rules).Should(HaveLen(1))
+				rule := validatingWebhookConfiguration.Webhooks[0].Rules[0]
+				g.Expect(rule.Operations).Should(ConsistOf(admregv1.Create, admregv1.Update))
+				g.Expect(rule.APIGroups).Should(Equal([]string{""}))
+				g.Expect(rule.APIVersions).Should(Equal([]string{"v1"}))
+				g.Expect(rule.Resources).Should(Equal([]string{"pods"}))
+			}, timeout, pollInterval).Should(Succeed())
+
+			By("MutatingWebhookConfiguration should NOT have rules from spec.webhook, should use default operations")
+			mutatingWebhookConfiguration := &admregv1.MutatingWebhookConfiguration{}
+			Eventually(func(g Gomega) {
+				err := K8sClient.Get(ctx, mutatingWebhookName, mutatingWebhookConfiguration)
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				// Verify the mutating webhook does NOT have the custom rules
+				// It should have default operations (CREATE, UPDATE) not the custom pod rules
+				g.Expect(mutatingWebhookConfiguration.Webhooks[0].Rules).Should(HaveLen(1))
+				rule := mutatingWebhookConfiguration.Webhooks[0].Rules[0]
+				// Should have default operations, not custom rules
+				g.Expect(rule.Operations).Should(ConsistOf(admregv1.Create, admregv1.Update))
+				// Should NOT be restricted to pods only
+				g.Expect(rule.Resources).Should(Equal([]string{"*"}))
+			}, timeout, pollInterval).Should(Succeed())
+		})
 	})
 
 	Describe("Test in Openshift Env", Label("openshift"), Ordered, Serial, func() {


### PR DESCRIPTION
Unlike other webhook configs, this is implemented in a way that separates the validating and mutating webhooks rather than sharing the rules.

ref: https://issues.redhat.com/browse/ACM-15572
Assisted-by: Claude code

Blocked by:
- #607 
- #610 
- #627 