### PR TITLE
Fix podAnnotation issue in Openshift env

### DIFF
--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -1051,7 +1051,8 @@ func setCommonConfig(log logr.Logger, obj *unstructured.Unstructured, config ope
 // profile unless there is a ClusterServiceVersion present, which is not the case for the Gatekeeper operand namespace.
 // Add --disable-cert-rotation arguments
 func openShiftDeploymentOverrides(obj *unstructured.Unstructured) error {
-	unstructured.RemoveNestedField(obj.Object, "spec", "template", "metadata", "annotations")
+	unstructured.RemoveNestedField(obj.Object, "spec", "template", "metadata",
+		"annotations", "container.seccomp.security.alpha.kubernetes.io/manager")
 
 	containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
 	if err != nil {

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -1361,6 +1361,50 @@ var _ = Describe("Gatekeeper", func() {
 				}, 5, pollInterval).Should(BeTrue())
 			})
 		})
+
+		Describe("Test PodAnnotations", func() {
+			It("Should propagate PodAnnotations to Gatekeeper deployments", func(ctx SpecContext) {
+				gatekeeper := emptyGatekeeper()
+				annotations := map[string]string{
+					"test-annotation": "test-value",
+				}
+				gatekeeper.Spec.PodAnnotations = annotations
+
+				By("Creating Gatekeeper resource with PodAnnotations", func() {
+					Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
+				})
+
+				By("Checking audit deployment annotations", func() {
+					Eventually(func(g Gomega) {
+						audit := &appsv1.Deployment{}
+						err := K8sClient.Get(ctx, types.NamespacedName{
+							Namespace: openshiftNamespace,
+							Name:      "gatekeeper-audit",
+						}, audit)
+						g.Expect(err).ShouldNot(HaveOccurred())
+						g.Expect(audit.Spec.Template.Annotations).
+							Should(HaveKeyWithValue("test-annotation", "test-value"))
+						g.Expect(audit.Spec.Template.Annotations).
+							ShouldNot(HaveKey("container.seccomp.security.alpha.kubernetes.io/manager"))
+					}, timeout, pollInterval).Should(Succeed())
+				})
+
+				By("Checking webhook deployment annotations", func() {
+					Eventually(func(g Gomega) {
+						webhook := &appsv1.Deployment{}
+						err := K8sClient.Get(ctx, types.NamespacedName{
+							Namespace: openshiftNamespace,
+							Name:      "gatekeeper-controller-manager",
+						}, webhook)
+						g.Expect(err).ShouldNot(HaveOccurred())
+						g.Expect(webhook.Spec.Template.Annotations).
+							Should(HaveKeyWithValue("test-annotation", "test-value"))
+						g.Expect(webhook.Spec.Template.Annotations).
+							ShouldNot(HaveKey("container.seccomp.security.alpha.kubernetes.io/manager"))
+					}, timeout, pollInterval).Should(Succeed())
+				})
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
**Problem**
After the refactoring introduced in version 3.20, the logic responsible for syncing the Gatekeeper CR to the underlying Deployments failed to include the podAnnotations field in the pod template specification. Consequently, while the operator successfully reconciled the CR, the resulting pods did not carry the user-defined annotations (e.g., custom monitoring labels, logging sidecar hints, or security tags).

**Fix**
Remove `	unstructured.RemoveNestedField(obj.Object, "spec", "template", "metadata", "annotations")`  under openShiftDeploymentOverrides function

Ref: https://issues.redhat.com/browse/ACM-27985