### PR TITLE
[release-3.21] fix: update RBAC logic for controller-gen update

### DIFF
--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -543,7 +543,7 @@ func (r *GatekeeperReconciler) crudResource(
 		Name:      obj.GetName(),
 	}
 
-	logger := r.Log.WithValues("Gatekeeper resource", namespacedName)
+	logger := r.Log.WithValues("Gatekeeper resource", namespacedName, "kind", obj.GetKind())
 
 	// Skip adding a controller reference for the namespace so that a deletion
 	// of the Gatekeeper CR does not also delete the namespace and everything
@@ -891,37 +891,42 @@ func webhookConfigurationOverrides(
 	return nil
 }
 
-type matchRuleFunc func(map[string]interface{}) (bool, error)
-
-var matchMutatingRBACRuleFns = []matchRuleFunc{
-	matchGatekeeperMutatingRBACRule,
-	matchMutatingWebhookConfigurationRBACRule,
-}
+type matchRuleFunc func(map[string]interface{}) (map[string]interface{}, bool, error)
 
 func removeMutatingRBACRules(obj *unstructured.Unstructured) error {
-	for _, f := range matchMutatingRBACRuleFns {
-		if err := removeRBACRule(obj, f); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return removeRBACRules(
+		obj,
+		[]matchRuleFunc{
+			matchGatekeeperMutatingRBACRule,
+			matchMutatingWebhookConfigurationRBACRule,
+		},
+	)
 }
 
-func removeRBACRule(obj *unstructured.Unstructured, matchRuleFn matchRuleFunc) error {
+func removeRBACRules(obj *unstructured.Unstructured, matchRuleFns []matchRuleFunc) error {
 	rules, found, err := unstructured.NestedSlice(obj.Object, "rules")
 	if err != nil || !found {
 		return errors.Wrapf(err, "Failed to retrieve rules from clusterrole")
 	}
 
-	for i, rule := range rules {
-		r := rule.(map[string]interface{})
-		if found, err := matchRuleFn(r); err != nil {
-			return err
-		} else if found {
-			rules = append(rules[:i], rules[i+1:]...)
+	for _, f := range matchRuleFns {
+		for i, rule := range rules {
+			r := rule.(map[string]interface{})
 
-			break
+			newRule, found, err := f(r)
+			if err != nil {
+				return err
+			}
+
+			if found {
+				if newRule != nil {
+					rules[i] = newRule
+				} else {
+					rules = append(rules[:i], rules[i+1:]...)
+				}
+
+				break
+			}
 		}
 	}
 
@@ -932,36 +937,52 @@ func removeRBACRule(obj *unstructured.Unstructured, matchRuleFn matchRuleFunc) e
 	return nil
 }
 
-func matchGatekeeperMutatingRBACRule(rule map[string]interface{}) (bool, error) {
-	apiGroups, found, err := unstructured.NestedStringSlice(rule, "apiGroups")
+func matchGatekeeperMutatingRBACRule(rule map[string]interface{}) (map[string]interface{}, bool, error) {
+	apiGroups, found, err := unstructured.NestedSlice(rule, "apiGroups")
 	if !found || err != nil {
-		return false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
+		return nil, false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
 	}
 
 	if slices.Contains(apiGroups, "mutations.gatekeeper.sh") {
-		return true, nil
+		if len(apiGroups) == 1 {
+			return nil, true, nil
+		}
+
+		rule["apiGroups"] = slices.DeleteFunc(apiGroups, func(apiGroup interface{}) bool {
+			return apiGroup == "mutations.gatekeeper.sh"
+		})
+
+		return rule, true, nil
 	}
 
-	return false, nil
+	return nil, false, nil
 }
 
-func matchMutatingWebhookConfigurationRBACRule(rule map[string]interface{}) (bool, error) {
-	apiGroups, found, err := unstructured.NestedStringSlice(rule, "apiGroups")
+func matchMutatingWebhookConfigurationRBACRule(rule map[string]interface{}) (map[string]interface{}, bool, error) {
+	apiGroups, found, err := unstructured.NestedSlice(rule, "apiGroups")
 	if !found || err != nil {
-		return false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
+		return nil, false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
 	}
 
-	resources, found, err := unstructured.NestedStringSlice(rule, "resources")
+	resources, found, err := unstructured.NestedSlice(rule, "resources")
 	if !found || err != nil {
-		return false, errors.Wrapf(err, "Failed to retrieve resources from rule")
+		return nil, false, errors.Wrapf(err, "Failed to retrieve resources from rule")
 	}
 
 	if slices.Contains(apiGroups, "admissionregistration.k8s.io") &&
 		slices.Contains(resources, "mutatingwebhookconfigurations") {
-		return true, nil
+		if len(resources) == 1 {
+			return nil, true, nil
+		}
+
+		rule["resources"] = slices.DeleteFunc(resources, func(resource interface{}) bool {
+			return resource == "mutatingwebhookconfigurations"
+		})
+
+		return rule, true, nil
 	}
 
-	return false, nil
+	return nil, false, nil
 }
 
 func containerOverrides(obj *unstructured.Unstructured, spec operatorv1alpha1.GatekeeperSpec) error {

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -1928,160 +1928,56 @@ func TestSetCertNamespace(t *testing.T) {
 func TestMutationRBACConfig(t *testing.T) {
 	g := NewWithT(t)
 
-	gatekeeper := defaultGatekeeper()
-
 	clusterRoleObj, err := util.GetManifestObject(ClusterRoleFile)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(clusterRoleObj).ToNot(BeNil())
-
-	// Test default RBAC config
-	obj := clusterRoleObj.DeepCopy()
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err := unstructured.NestedSlice(obj.Object, "rules")
+	initialRules, found, err := unstructured.NestedSlice(clusterRoleObj.Object, "rules")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
 
-	matchCount := 0
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			if found {
-				matchCount++
-			}
-		}
+	expectedModifications := []interface{}{
+		map[string]interface{}{
+			"apiGroups": []interface{}{
+				"connection.gatekeeper.sh", "constraints.gatekeeper.sh",
+				"expansion.gatekeeper.sh", "status.gatekeeper.sh",
+			},
+			"resources": []interface{}{"*"},
+			"verbs":     []interface{}{"create", "delete", "get", "list", "patch", "update", "watch"},
+		},
+	}
+	expectedRemovals := []interface{}{
+		map[string]interface{}{
+			"apiGroups":     []interface{}{"admissionregistration.k8s.io"},
+			"resourceNames": []interface{}{"gatekeeper-mutating-webhook-configuration"},
+			"resources":     []interface{}{"mutatingwebhookconfigurations"},
+			"verbs":         []interface{}{"delete", "get", "list", "patch", "update", "watch"},
+		},
 	}
 
-	g.Expect(matchCount).To(Equal(len(matchMutatingRBACRuleFns)))
+	// defaultGatekeeper uses MutatingWebhook Enabled; crOverrides keeps mutating RBAC rules iff
+	// MutatingWebhook.IsEnabled() (see ClusterRoleFile case in crOverrides).
+	for _, tc := range []struct {
+		mutatingWebhook operatorv1alpha1.Mode
+	}{
+		{operatorv1alpha1.Enabled},
+		{operatorv1alpha1.Disabled},
+	} {
+		gatekeeper := defaultGatekeeper()
+		gatekeeper.Spec.MutatingWebhook = tc.mutatingWebhook
 
-	// Test RBAC config when mutating webhook mode is nil
-	obj = clusterRoleObj.DeepCopy()
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
+		obj := clusterRoleObj.DeepCopy()
+		err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
+		g.Expect(err).ToNot(HaveOccurred())
+		rules, found, err := unstructured.NestedSlice(obj.Object, "rules")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(rules).NotTo(BeEmpty())
 
-	matchCount = 0
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			if found {
-				matchCount++
-			}
+		if tc.mutatingWebhook.IsEnabled() {
+			g.Expect(rules).To(Equal(initialRules))
+		} else {
+			g.Expect(rules).To(ContainElements(expectedModifications))
+			g.Expect(rules).To(Not(ContainElements(expectedRemovals)))
 		}
 	}
-
-	g.Expect(matchCount).To(Equal(len(matchMutatingRBACRuleFns)))
-
-	// Test RBAC config when mutating webhook mode is nil
-	obj = clusterRoleObj.DeepCopy()
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
-
-	// Test RBAC config when mutating webhook mode is disabled
-	obj = clusterRoleObj.DeepCopy()
-	gatekeeper.Spec.MutatingWebhook = operatorv1alpha1.Disabled
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(found).To(BeFalse())
-		}
-	}
-
-	// Test RBAC config when mutating webhook mode is enabled
-	obj = clusterRoleObj.DeepCopy()
-	gatekeeper.Spec.MutatingWebhook = operatorv1alpha1.Enabled
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
-
-	matchCount = 0
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			if found {
-				matchCount++
-			}
-		}
-	}
-
-	g.Expect(matchCount).To(Equal(len(matchMutatingRBACRuleFns)))
-
-	// Test RBAC config when mutating webhook mode is disabled
-	obj = clusterRoleObj.DeepCopy()
-	gatekeeper.Spec.MutatingWebhook = operatorv1alpha1.Disabled
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(found).To(BeFalse())
-		}
-	}
-
-	// Test RBAC config when mutating webhook mode is enabled
-	obj = clusterRoleObj.DeepCopy()
-	gatekeeper.Spec.MutatingWebhook = operatorv1alpha1.Enabled
-
-	err = crOverrides(logr.Logger{}, gatekeeper, ClusterRoleFile, obj, namespace, false, false)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(found).To(BeTrue())
-	g.Expect(rules).NotTo(BeEmpty())
-
-	matchCount = 0
-
-	for _, rule := range rules {
-		r := rule.(map[string]interface{})
-		for _, f := range matchMutatingRBACRuleFns {
-			found, err := f(r)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			if found {
-				matchCount++
-			}
-		}
-	}
-
-	g.Expect(matchCount).To(Equal(len(matchMutatingRBACRuleFns)))
 }

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -1733,6 +1733,9 @@ func checkPodsStable(ctx SpecContext, labelSelector, deploymentName string) {
 			if _, ok := restartMap[pod.Name]; !ok {
 				restartMap[pod.Name] = map[string]int32{}
 			}
+			if pod.Status.Phase == corev1.PodSucceeded {
+				continue
+			}
 			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "Pod %s should be Running", pod.Name)
 			g.Expect(pod.Status.ContainerStatuses).NotTo(
 				BeEmpty(),


### PR DESCRIPTION
With the consolidated RBAC, the logic for removal needs to be more targeted.

ref: https://redhat.atlassian.net/browse/ACM-32769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced logging to include Kubernetes resource kind for improved debugging and visibility.
  * Improved RBAC rule handling logic with more flexible rule modification and deletion capabilities.

* **Tests**
  * Updated test assertions to validate RBAC rule behavior using direct slice comparisons instead of iterative matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->