### PR TITLE
chore: group GitHub action updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,13 +24,13 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "groupName": "containerfile images ({{{baseBranch}}})",
+      "groupName": "Bundle containerfile images",
       "matchManagers": ["dockerfile"],
       "ignorePaths": ["**/bundle.Dockerfile.rhtap"],
       "pinDigests": true
     },
     {
-      "groupName": "containerfile images ({{{baseBranch}}})",
+      "groupName": "Containerfile images",
       "matchManagers": ["dockerfile"],
       "ignorePaths": ["**/Dockerfile.rhtap"],
       "pinDigests": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency-management configuration to use consistent, static group names for container-related updates.
  * Preserved existing matching and digest-pinning behavior for the different container update rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->