### PR TITLE
Increase operator manager memory request and remove limits

### DIFF
--- a/bundle/manifests/gatekeeper-operator-product.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator-product.clusterserviceversion.yaml
@@ -438,7 +438,7 @@ spec:
                 resources:
                   requests:
                     cpu: 100m
-                    memory: 512Mi
+                    memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/bundle/manifests/gatekeeper-operator-product.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator-product.clusterserviceversion.yaml
@@ -436,12 +436,9 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 100Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 512Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,12 +54,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 200m
-              memory: 100Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 512Mi
           env:
             - name: RELATED_IMAGE_GATEKEEPER
               value: quay.io/gatekeeper/gatekeeper:v3.21.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 128Mi
           env:
             - name: RELATED_IMAGE_GATEKEEPER
               value: quay.io/gatekeeper/gatekeeper:v3.21.1

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -2232,7 +2232,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 512Mi
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -2230,12 +2230,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 200m
-            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary
- Remove resource limits from the gatekeeper-operator manager pod to prevent OOMKilled after upgrading to Gatekeeper v3.21.0
- Increase the operator manager memory request from 20Mi to 512Mi
- Update deploy manifest and OLM bundle CSV to match

## Test plan
- [x] `go test ./controllers -run TestResources`
- [ ] Deploy operator via OLM and verify `gatekeeper-operator-controller` pod starts without OOMKilled
- [ ] Confirm operator manager pod has requests only (no limits) and 512Mi memory request

Ref: https://redhat.atlassian.net/browse/ACM-35037

Made with [Cursor](https://cursor.com)